### PR TITLE
fix bug in prior for baseline CFR

### DIFF
--- a/global_estimates/scripts/plot_temporal/run_bayesian_model.R
+++ b/global_estimates/scripts/plot_temporal/run_bayesian_model.R
@@ -35,7 +35,7 @@ run_bayesian_model <- function (data, n_inducing = 10) {
   # Gaussian distribution, truncated to allowable values.
   true_cfr_mean <- cCFRBaseline
   true_cfr_sigma <- mean(abs(cCFREstimateRange - cCFRBaseline)) / 1.96
-  baseline_cfr_perc <- normal(true_cfr_mean, true_cfr_sigma, truncation = c(0, 1))
+  baseline_cfr_perc <- normal(true_cfr_mean, true_cfr_sigma, truncation = c(0, 100))
   
   # compute the expected number of deaths at each timepoint, given the true CFR,
   # number of reported cases with known outcomes, and reporting rate


### PR DESCRIPTION
Gah, I just found a bug on specifying the prior for baseline CFR (muddled up between percentages and proportions), which would have been biasing the estimates.

Another PR coming with other tweaks to tuning the model, and to the model structure to prevent excessive wiggliness, but this is the more urgent one.